### PR TITLE
npm: Update Git path from bmp085 to bmp085-sensor

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbridges/bmp085.git"
+    "url": "git+https://github.com/dbridges/bmp085-sensor"
   },
   "keywords": [
     "bmp085",
@@ -24,7 +24,7 @@
   "author": "Daniel Bridges",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dbridges/bmp085/issues"
+    "url": "https://github.com/dbridges/bmp085-sensor/issues"
   },
-  "homepage": "https://github.com/dbridges/bmp085"
+  "homepage": "https://github.com/dbridges/bmp085-sensor"
 }


### PR DESCRIPTION
This will prevent ambiguity with other driver:

https://www.npmjs.com/package/bmp085

Relate-to: https://github.com/dbridges/bmp085-sensor/issues/3
Change-Id: Ia3a03f78c933b9cec3b421209036dcee93bccfa2
Signed-off-by: Philippe Coval <p.coval@samsung.com>