### PR TITLE
iotjs: Port to alt runtime using async-lite

### DIFF
--- a/bmp085-sensor.js
+++ b/bmp085-sensor.js
@@ -9,7 +9,25 @@ module.exports = function BMP085(options) {
     units: 'metric'
   };
   options.address = options.address || 0x77;
-  var wire = new i2c(options.address);
+  var wire;
+  if (!process.iotjs) {
+    wire = new i2c(options.address);
+  } else {
+    options.bus = options.bus || 1;
+    options.device = options.device || '/dev/i2c-1';
+    wire = i2c.openSync(options);
+    wire.writeBytes = function(offset, bytes, callback) {
+      var bytes = [offset].concat(bytes);
+      this.writeSync(bytes);
+      callback && callback(null);
+    }
+    wire.readBytes = function(offset, len, callback) {
+      this.writeSync([offset]);
+      this.read(len, function(err, res) {
+        callback && callback(err, res);
+      });
+    }
+  }
   var cal = {};
 
   var BMP085_CONTROL_REGISTER  = 0xF4;


### PR DESCRIPTION
i2c is not needed because native I2C module will be used

Usage:

```
git clone https://github.com/rzr/async-lite iotjs_modules/async
iotjs test
{
  "pressure": 99406.04496626806,
  "temperature": 22.5
}
```

Change-Id: I97d4248d87f59cd9468dc7fb90c1f2c04dd1d55c
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>